### PR TITLE
[workflow] feat: Fetch settings

### DIFF
--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -21,7 +21,7 @@ on:
         type: string
       role:
         description: |
-          An optional role to construct a db connection string after branch creation.
+          An optional role for constructing a database connection string after branch creation.
           If not specified, the first possible role will be used.
         required: false
         type: string

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -48,7 +48,7 @@ jobs:
           || github.event.action == 'opened'
           || github.event.action == 'reopened') }}
         run: |
-          if [ "${{ inputs.parent_branch }}" -ne "" -a "${{ inputs.db }}" -ne ""  -a "${{ inputs.role }}" -ne ""]; then \
+          if [ "${{ inputs.parent_branch }}" != "" -a "${{ inputs.db }}" != ""  -a "${{ inputs.role }}" != ""]; then \
             echo "workflow_parent=${{ inputs.parent_branch }}" >> $GITHUB_OUTPUT
             echo "workflow_db=${{ inputs.db }}" >> $GITHUB_OUTPUT
             echo "workflow_role=${{ inputs.role }}" >> $GITHUB_OUTPUT
@@ -57,17 +57,17 @@ jobs:
           WORKFLOW=$(curl --fail-with-body -sSL -H "Authorization: Bearer ${{ secrets.NEON_API_KEY }}" \
             ${{ inputs.api_url }}/projects/${{ inputs.project_id }}/applications/github \
             | jq -r ".workflows[] | select(.type == \"pr_branches\")")
-          if [ "${{ inputs.parent_branch }}" -ne "" ]; then \
+          if [ "${{ inputs.parent_branch }}" != "" ]; then \
             echo "workflow_parent=$(echo $WORKFLOW | jq .template_values.parent)" >> $GITHUB_OUTPUT
           else
             echo "workflow_parent=${{ inputs.parent_branch }}" >> $GITHUB_OUTPUT
           fi
-          if [ "${{ inputs.db }}" -ne "" ]; then \
+          if [ "${{ inputs.db }}" != "" ]; then \
             echo "workflow_db=$(echo $WORKFLOW | jq .template_values.db)" >> $GITHUB_OUTPUT
           else 
             echo "workflow_db=${{ inputs.db }}" >> $GITHUB_OUTPUT
           fi
-          if [ "${{ inputs.role }}" -ne "" ]; then \
+          if [ "${{ inputs.role }}" != "" ]; then \
             echo "workflow_role=$(echo $WORKFLOW | jq .template_values.role)" >> $GITHUB_OUTPUT
           else
             echo "workflow_role=${{ inputs.role }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -15,7 +15,7 @@ on:
         type: string
       db:
         description: |
-          An optional db to construct a db connection string after branch creation.
+          An optional role for constructing a database connection string after branch creation.
           If not specified, the first possible db will be used.
         required: false
         type: string
@@ -27,10 +27,10 @@ on:
         type: string
       oauth_url:
         type: string
-        description: An URL to Neon OAuth service. Should be only provided if you are workflow developer.
+        description: A URL for the Neon OAuth service.
       api_url:
         type: string
-        description: An URL to Neon API service. Should be only provided if you are workflow developer.
+        description: A URL for the Neon API service.
     secrets:
       NEON_API_KEY:
         description: A Neon API key is required to access the APIs for branch creation, deletion, and reset.

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -48,7 +48,7 @@ jobs:
           || github.event.action == 'opened'
           || github.event.action == 'reopened') }}
         run: |
-          if [ ${{ inputs.parent_branch }} -ne "" -a ${{ inputs.db }} -ne ""  -a ${{ inputs.role }} -ne ""]; then \
+          if [ "${{ inputs.parent_branch }}" -ne "" -a "${{ inputs.db }}" -ne ""  -a "${{ inputs.role }}" -ne ""]; then \
             echo "workflow_parent=${{ inputs.parent_branch }}" >> $GITHUB_OUTPUT
             echo "workflow_db=${{ inputs.db }}" >> $GITHUB_OUTPUT
             echo "workflow_role=${{ inputs.role }}" >> $GITHUB_OUTPUT
@@ -57,17 +57,17 @@ jobs:
           WORKFLOW=$(curl --fail-with-body -fsSL -H "Authorization: Bearer ${{ secrets.NEON_API_KEY }}" \
             ${{ inputs.api_url }}/projects/${{ inputs.project_id }}/applications/github \
             | jq -r ".workflows[] | select(.type == \"pr_branches\")")
-          if [ ${{ inputs.parent_branch }} -ne "" ]; then \
+          if [ "${{ inputs.parent_branch }}" -ne "" ]; then \
             echo "workflow_parent=$(echo $WORKFLOW | jq .template_values.parent)" >> $GITHUB_OUTPUT
           else
             echo "workflow_parent=${{ inputs.parent_branch }}" >> $GITHUB_OUTPUT
           fi
-          if [ ${{ inputs.db }} -ne "" ]; then \
+          if [ "${{ inputs.db }}" -ne "" ]; then \
             echo "workflow_db=$(echo $WORKFLOW | jq .template_values.db)" >> $GITHUB_OUTPUT
           else 
             echo "workflow_db=${{ inputs.db }}" >> $GITHUB_OUTPUT
           fi
-          if [ ${{ inputs.role }} -ne "" ]; then \
+          if [ "${{ inputs.role }}" -ne "" ]; then \
             echo "workflow_role=$(echo $WORKFLOW | jq .template_values.role)" >> $GITHUB_OUTPUT
           else
             echo "workflow_role=${{ inputs.role }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -9,30 +9,29 @@ on:
         type: string
       parent_branch:
         description: |
-          A parameter to create a new branch. 
-          The parent branch name or id or LSN or timestamp. 
-          By default the primary branch is used.
+          The parent branch name or id or LSN or timestamp to create a new branch. 
+          If not specified, primary branch is used.
         required: false
         type: string
       db:
-        description: A parameter to create a new branch.
+        description: |
+          An optional role to construct a db connection string after branch creation.
         required: false
         type: string
       role:
-        description: A parameter to create a new branch.
+        description: |
+          An optional role to construct a db connection string after branch creation..
         required: false
         type: string
       oauth_url:
         type: string
-        description: An URL to Neon OAuth service
-        default: 'https://console.neon.tech/api/v2'
+        description: An URL to Neon OAuth service.
       api_url:
         type: string
         description: An URL to Neon API service
-        default: ''
     secrets:
       NEON_API_KEY:
-        description: A Neon API key.
+        description: A Neon API key is required to access the APIs for branch creation, deletion, reset.
         required: true
 
 jobs:
@@ -40,16 +39,21 @@ jobs:
     name: Create/Delete Branch for Pull Request Job
     runs-on: ubuntu-latest
     steps:
-#      - name: Fetch integration data
-#        shell: bash
-#        run: |
-#          WORKFLOW=$(curl -H "accept: application/json" -H "Authorization: Bearer ${{ secrets.NEON_API_KEY }}" \
-#            ${{ inputs.api_url }}/projects/${{ inputs.project_id }}/applications/github \
-#            | jq -r ".workflows[] | select(.type == \"pr_branches\")")
-#          echo $WORKFLOW
-#          echo "workflow_parent=$(echo $WORKFLOW | jq .template_values.parent)" >> $GITHUB_ENV
-#          echo "workflow_db=$(echo $WORKFLOW | jq .template_values.db)" >> $GITHUB_ENV
-#          echo "workflow_role=$(echo $WORKFLOW | jq .template_values.role)" >> $GITHUB_ENV
+      - name: Fetch integration data
+        id: fetch
+        shell: bash
+        if: |
+          ${{ github.event_name == 'pull_request' && (
+          github.event.action == 'synchronize'
+          || github.event.action == 'opened'
+          || github.event.action == 'reopened') }}
+        run: |
+          WORKFLOW=$(curl -fsSL -H "Authorization: Bearer ${{ secrets.NEON_API_KEY }}" \
+            ${{ inputs.api_url }}/projects/${{ inputs.project_id }}/applications/github \
+            | jq -r ".workflows[] | select(.type == \"pr_branches\")")
+          echo "workflow_parent=$(echo $WORKFLOW | jq .template_values.parent)" >> $GITHUB_OUTPUT
+          echo "workflow_db=$(echo $WORKFLOW | jq .template_values.db)" >> $GITHUB_OUTPUT
+          echo "workflow_role=$(echo $WORKFLOW | jq .template_values.role)" >> $GITHUB_OUTPUT
 
       - name: Create Neon Branch
         uses: neondatabase/create-branch-action@v5.0.0
@@ -57,13 +61,13 @@ jobs:
           ${{ github.event_name == 'pull_request' && (
           github.event.action == 'synchronize'
           || github.event.action == 'opened'
-          || github.event.action == 'reopened')  }}
+          || github.event.action == 'reopened') }}
         with:
           project_id: ${{ inputs.project_id }}
           branch_name: preview/pr-${{ github.event.number }}
-          parent: ${{ inputs.parent_branch }}
-          database: ${{ inputs.db }}
-          username: ${{ inputs.role }}
+          parent: ${{ steps.run_tests.outputs.fetch.workflow_parent }}
+          database: ${{ steps.run_tests.outputs.fetch.workflow_db }}
+          username: ${{ steps.run_tests.outputs.fetch.workflow_role }}
           api_key: ${{ secrets.NEON_API_KEY }}
         env:
           NEON_OAUTH_HOST: ${{ inputs.oauth_url }}

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -48,7 +48,8 @@ jobs:
           echo "workflow_role=$(echo $WORKFLOW | jq .template_values.role)" >> $GITHUB_ENV
 
       - name: Create Neon Branch
-        uses: neondatabase/create-branch-action@v5.0.0
+        #uses: neondatabase/create-branch-action@v5.0.0
+        uses: neondatabase/create-branch-action@feat/expose_auth_api_urls_params
         if: |
           ${{ github.event_name == 'pull_request' && (
           github.event.action == 'synchronize'

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -48,7 +48,7 @@ jobs:
           || github.event.action == 'opened'
           || github.event.action == 'reopened') }}
         run: |
-          WORKFLOW=$(curl -fsSL -H "Authorization: Bearer ${{ secrets.NEON_API_KEY }}" \
+          WORKFLOW=$(curl --fail-with-body -fsSL -H "Authorization: Bearer ${{ secrets.NEON_API_KEY }}" \
             ${{ inputs.api_url }}/projects/${{ inputs.project_id }}/applications/github \
             | jq -r ".workflows[] | select(.type == \"pr_branches\")")
           echo "workflow_parent=$(echo $WORKFLOW | jq .template_values.parent)" >> $GITHUB_OUTPUT

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -12,15 +12,15 @@ on:
           A parameter to create a new branch. 
           The parent branch name or id or LSN or timestamp. 
           By default the primary branch is used.
-        required: true
+        required: false
         type: string
       db:
         description: A parameter to create a new branch.
-        required: true
+        required: false
         type: string
       role:
         description: A parameter to create a new branch.
-        required: true
+        required: false
         type: string
     secrets:
       inherit:
@@ -30,6 +30,13 @@ jobs:
     name: Create/Delete Branch for Pull Request Job
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch integration data
+        shell: bash
+        run: |
+          WORKFLOW=$(curl -H "accept: application/json" -H "Authorization: Bearer ${{ secrets.NEON_API_KEY }}" \ 
+          https://console.neon.tech/api/v2/projects/${{ inputs.project_id} }}/applications/github \
+          | jq -r ".workflows[] | select(.type == 'pr_branches')")
+          echo $WORKFLOW
       - name: Create Neon Branch
         uses: neondatabase/create-branch-action@v5.0.0
         if: |

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -31,7 +31,9 @@ on:
         description: An URL to Neon API service
         default: ''
     secrets:
-      inherit:
+      NEON_API_KEY:
+        description: A Neon API key.
+        required: true
 
 jobs:
   neon_branch_management:

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -54,7 +54,7 @@ jobs:
             echo "workflow_role=${{ inputs.role }}" >> $GITHUB_OUTPUT
             exit 0;
           fi
-          WORKFLOW=$(curl --fail-with-body -fsSL -H "Authorization: Bearer ${{ secrets.NEON_API_KEY }}" \
+          WORKFLOW=$(curl --fail-with-body -sSL -H "Authorization: Bearer ${{ secrets.NEON_API_KEY }}" \
             ${{ inputs.api_url }}/projects/${{ inputs.project_id }}/applications/github \
             | jq -r ".workflows[] | select(.type == \"pr_branches\")")
           if [ "${{ inputs.parent_branch }}" -ne "" ]; then \

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -50,8 +50,7 @@ jobs:
           echo "workflow_role=$(echo $WORKFLOW | jq .template_values.role)" >> $GITHUB_ENV
 
       - name: Create Neon Branch
-        #uses: neondatabase/create-branch-action@v5.0.0
-        uses: neondatabase/create-branch-action@feat/expose_auth_api_urls_params
+        uses: neondatabase/create-branch-action@v5.0.0
         if: |
           ${{ github.event_name == 'pull_request' && (
           github.event.action == 'synchronize'

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -98,7 +98,9 @@ jobs:
           github.event_name == 'pull_request' &&
           (github.event.action == 'synchronize' ||
            github.event.action == 'opened' ||
-           github.event.action == 'reopened')
+           github.event.action == 'reopened' ||
+           github.event.action == 'labeled'
+          )
         with:
           project_id: ${{ inputs.project_id }}
           parent: true

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -33,7 +33,7 @@ on:
         description: An URL to Neon API service. Should be only provided if you are workflow developer.
     secrets:
       NEON_API_KEY:
-        description: A Neon API key is required to access the APIs for branch creation, deletion, reset.
+        description: A Neon API key is required to access the APIs for branch creation, deletion, and reset.
         required: true
 
 jobs:

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -48,11 +48,6 @@ jobs:
           || github.event.action == 'opened'
           || github.event.action == 'reopened') }}
         run: |
-          echo "${{ github.event.pull_request.labels }}"
-          echo "${{ join(github.event.pull_request.labels) }}"
-          echo "${{ 'Reset Neon Branch' }}"
-          echo ${{ contains(github.event.pull_request.labels.*.name, 'Reset Neon Branch') }}
-          echo ${{ contains(join(github.event.pull_request.labels.*.name), 'Reset Neon Branch') }}
           if [ "${{ inputs.parent_branch }}" != "" ] && [ "${{ inputs.db }}" != "" ] && [ "${{ inputs.role }}" != "" ]; then \
             echo "workflow_parent=${{ inputs.parent_branch }}" >> $GITHUB_OUTPUT
             echo "workflow_db=${{ inputs.db }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -39,8 +39,8 @@ jobs:
     name: Create/Delete Branch for Pull Request Job
     runs-on: ubuntu-latest
     steps:
-      - name: Fetch integration data
-        id: fetch
+      - name: Prepare create params
+        id: params
         shell: bash
         if: |
           ${{ github.event_name == 'pull_request' && (
@@ -48,12 +48,30 @@ jobs:
           || github.event.action == 'opened'
           || github.event.action == 'reopened') }}
         run: |
+          if [ ${{ inputs.parent_branch }} -ne "" -a ${{ inputs.db }} -ne ""  -a ${{ inputs.role }} -ne ""]; then \
+            echo "workflow_parent=${{ inputs.parent_branch }}" >> $GITHUB_OUTPUT
+            echo "workflow_db=${{ inputs.db }}" >> $GITHUB_OUTPUT
+            echo "workflow_role=${{ inputs.role }}" >> $GITHUB_OUTPUT
+            exit 0;
+          fi
           WORKFLOW=$(curl --fail-with-body -fsSL -H "Authorization: Bearer ${{ secrets.NEON_API_KEY }}" \
             ${{ inputs.api_url }}/projects/${{ inputs.project_id }}/applications/github \
             | jq -r ".workflows[] | select(.type == \"pr_branches\")")
-          echo "workflow_parent=$(echo $WORKFLOW | jq .template_values.parent)" >> $GITHUB_OUTPUT
-          echo "workflow_db=$(echo $WORKFLOW | jq .template_values.db)" >> $GITHUB_OUTPUT
-          echo "workflow_role=$(echo $WORKFLOW | jq .template_values.role)" >> $GITHUB_OUTPUT
+          if [ ${{ inputs.parent_branch }} -ne "" ]; then \
+            echo "workflow_parent=$(echo $WORKFLOW | jq .template_values.parent)" >> $GITHUB_OUTPUT
+          else
+            echo "workflow_parent=${{ inputs.parent_branch }}" >> $GITHUB_OUTPUT
+          fi
+          if [ ${{ inputs.db }} -ne "" ]; then \
+            echo "workflow_db=$(echo $WORKFLOW | jq .template_values.db)" >> $GITHUB_OUTPUT
+          else 
+            echo "workflow_db=${{ inputs.db }}" >> $GITHUB_OUTPUT
+          fi
+          if [ ${{ inputs.role }} -ne "" ]; then \
+            echo "workflow_role=$(echo $WORKFLOW | jq .template_values.role)" >> $GITHUB_OUTPUT
+          else
+            echo "workflow_role=${{ inputs.role }}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Create Neon Branch
         uses: neondatabase/create-branch-action@v5.0.0
@@ -65,9 +83,9 @@ jobs:
         with:
           project_id: ${{ inputs.project_id }}
           branch_name: preview/pr-${{ github.event.number }}
-          parent: ${{ steps.run_tests.outputs.fetch.workflow_parent }}
-          database: ${{ steps.run_tests.outputs.fetch.workflow_db }}
-          username: ${{ steps.run_tests.outputs.fetch.workflow_role }}
+          parent: ${{ steps.run_tests.outputs.params.workflow_parent }}
+          database: ${{ steps.run_tests.outputs.params.workflow_db }}
+          username: ${{ steps.run_tests.outputs.params.workflow_role }}
           api_key: ${{ secrets.NEON_API_KEY }}
         env:
           NEON_OAUTH_HOST: ${{ inputs.oauth_url }}

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -9,7 +9,7 @@ on:
         type: string
       parent_branch:
         description: |
-          The parent branch name or id or LSN or timestamp to create a new branch. 
+          The parent branch name, id, LSN, or timestamp to create a new branch. 
           If not specified, primary branch is used.
         required: false
         type: string

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -10,7 +10,7 @@ on:
       parent_branch:
         description: |
           The parent branch name, id, LSN, or timestamp to create a new branch. 
-          If not specified, primary branch is used.
+          If not specified, the primary branch is used.
         required: false
         type: string
       db:

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -33,9 +33,7 @@ jobs:
       - name: Fetch integration data
         shell: bash
         run: |
-          WORKFLOW=$(curl -H "accept: application/json" -H "Authorization: Bearer ${{ secrets.NEON_API_KEY }}" \ 
-          https://console.neon.tech/api/v2/projects/${{ inputs.project_id }}/applications/github \
-          | jq -r ".workflows[] | select(.type == \"pr_branches\")")
+          WORKFLOW=$(curl -H "accept: application/json" -H "Authorization: Bearer ${{ secrets.NEON_API_KEY }}" https://console.neon.tech/api/v2/projects/${{ inputs.project_id }}/applications/github | jq -r ".workflows[] | select(.type == \"pr_branches\")")
           echo $WORKFLOW
           echo "workflow_parent=$(echo $WORKFLOW | jq .template_values.parent)" >> $GITHUB_ENV
           echo "workflow_db=$(echo $WORKFLOW | jq .template_values.db)" >> $GITHUB_ENV

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -48,6 +48,11 @@ jobs:
           || github.event.action == 'opened'
           || github.event.action == 'reopened') }}
         run: |
+          echo "${{ github.event.pull_request.labels }}"
+          echo "${{ json(github.event.pull_request.labels) }}"
+          echo "${{ 'Reset Neon Branch' }}"
+          echo ${{ contains(github.event.pull_request.labels.*.name, 'Reset Neon Branch') }}
+          echo ${{ contains(json(github.event.pull_request.labels.*.name), 'Reset Neon Branch') }}
           if [ "${{ inputs.parent_branch }}" != "" ] && [ "${{ inputs.db }}" != "" ] && [ "${{ inputs.role }}" != "" ]; then \
             echo "workflow_parent=${{ inputs.parent_branch }}" >> $GITHUB_OUTPUT
             echo "workflow_db=${{ inputs.db }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -49,10 +49,10 @@ jobs:
           || github.event.action == 'reopened') }}
         run: |
           echo "${{ github.event.pull_request.labels }}"
-          echo "${{ json(github.event.pull_request.labels) }}"
+          echo "${{ join(github.event.pull_request.labels) }}"
           echo "${{ 'Reset Neon Branch' }}"
           echo ${{ contains(github.event.pull_request.labels.*.name, 'Reset Neon Branch') }}
-          echo ${{ contains(json(github.event.pull_request.labels.*.name), 'Reset Neon Branch') }}
+          echo ${{ contains(join(github.event.pull_request.labels.*.name), 'Reset Neon Branch') }}
           if [ "${{ inputs.parent_branch }}" != "" ] && [ "${{ inputs.db }}" != "" ] && [ "${{ inputs.role }}" != "" ]; then \
             echo "workflow_parent=${{ inputs.parent_branch }}" >> $GITHUB_OUTPUT
             echo "workflow_db=${{ inputs.db }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -48,7 +48,7 @@ jobs:
           || github.event.action == 'opened'
           || github.event.action == 'reopened') }}
         run: |
-          if [ "${{ inputs.parent_branch }}" != "" -a "${{ inputs.db }}" != ""  -a "${{ inputs.role }}" != ""]; then \
+          if [[ "${{ inputs.parent_branch }}" != "" -a "${{ inputs.db }}" != ""  -a "${{ inputs.role }}" != "" ]]; then \
             echo "workflow_parent=${{ inputs.parent_branch }}" >> $GITHUB_OUTPUT
             echo "workflow_db=${{ inputs.db }}" >> $GITHUB_OUTPUT
             echo "workflow_role=${{ inputs.role }}" >> $GITHUB_OUTPUT
@@ -57,17 +57,17 @@ jobs:
           WORKFLOW=$(curl --fail-with-body -sSL -H "Authorization: Bearer ${{ secrets.NEON_API_KEY }}" \
             ${{ inputs.api_url }}/projects/${{ inputs.project_id }}/applications/github \
             | jq -r ".workflows[] | select(.type == \"pr_branches\")")
-          if [ "${{ inputs.parent_branch }}" != "" ]; then \
+          if [[ "${{ inputs.parent_branch }}" != "" ]]; then \
             echo "workflow_parent=$(echo $WORKFLOW | jq .template_values.parent)" >> $GITHUB_OUTPUT
           else
             echo "workflow_parent=${{ inputs.parent_branch }}" >> $GITHUB_OUTPUT
           fi
-          if [ "${{ inputs.db }}" != "" ]; then \
+          if [[ "${{ inputs.db }}" != "" ]]; then \
             echo "workflow_db=$(echo $WORKFLOW | jq .template_values.db)" >> $GITHUB_OUTPUT
           else 
             echo "workflow_db=${{ inputs.db }}" >> $GITHUB_OUTPUT
           fi
-          if [ "${{ inputs.role }}" != "" ]; then \
+          if [[ "${{ inputs.role }}" != "" ]]; then \
             echo "workflow_role=$(echo $WORKFLOW | jq .template_values.role)" >> $GITHUB_OUTPUT
           else
             echo "workflow_role=${{ inputs.role }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -38,16 +38,16 @@ jobs:
     name: Create/Delete Branch for Pull Request Job
     runs-on: ubuntu-latest
     steps:
-      - name: Fetch integration data
-        shell: bash
-        run: |
-          WORKFLOW=$(curl -H "accept: application/json" -H "Authorization: Bearer ${{ secrets.NEON_API_KEY }}" \
-            ${{ inputs.api_url }}/projects/${{ inputs.project_id }}/applications/github \
-            | jq -r ".workflows[] | select(.type == \"pr_branches\")")
-          echo $WORKFLOW
-          echo "workflow_parent=$(echo $WORKFLOW | jq .template_values.parent)" >> $GITHUB_ENV
-          echo "workflow_db=$(echo $WORKFLOW | jq .template_values.db)" >> $GITHUB_ENV
-          echo "workflow_role=$(echo $WORKFLOW | jq .template_values.role)" >> $GITHUB_ENV
+#      - name: Fetch integration data
+#        shell: bash
+#        run: |
+#          WORKFLOW=$(curl -H "accept: application/json" -H "Authorization: Bearer ${{ secrets.NEON_API_KEY }}" \
+#            ${{ inputs.api_url }}/projects/${{ inputs.project_id }}/applications/github \
+#            | jq -r ".workflows[] | select(.type == \"pr_branches\")")
+#          echo $WORKFLOW
+#          echo "workflow_parent=$(echo $WORKFLOW | jq .template_values.parent)" >> $GITHUB_ENV
+#          echo "workflow_db=$(echo $WORKFLOW | jq .template_values.db)" >> $GITHUB_ENV
+#          echo "workflow_role=$(echo $WORKFLOW | jq .template_values.role)" >> $GITHUB_ENV
 
       - name: Create Neon Branch
         uses: neondatabase/create-branch-action@v5.0.0
@@ -59,9 +59,9 @@ jobs:
         with:
           project_id: ${{ inputs.project_id }}
           branch_name: preview/pr-${{ github.event.number }}
-          parent: ${{ env.workflow_parent }}
-          database: ${{ env.workflow_db }}
-          username: ${{ env.workflow_role }}
+          parent: ${{ inputs.parent_branch }}
+          database: ${{ inputs.db }}
+          username: ${{ inputs.role }}
           api_key: ${{ secrets.NEON_API_KEY }}
         env:
           NEON_OAUTH_HOST: ${{ inputs.oauth_url }}

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -34,7 +34,7 @@ jobs:
         shell: bash
         run: |
           WORKFLOW=$(curl -H "accept: application/json" -H "Authorization: Bearer ${{ secrets.NEON_API_KEY }}" \ 
-          https://console.neon.tech/api/v2/projects/${{ inputs.project_id} }}/applications/github \
+          https://console.neon.tech/api/v2/projects/${{ inputs.project_id }}/applications/github \
           | jq -r ".workflows[] | select(.type == 'pr_branches')")
           echo $WORKFLOW
           echo "workflow_parent=$(echo $WORKFLOW | jq .template_values.parent)" >> $GITHUB_ENV

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -43,10 +43,10 @@ jobs:
         id: params
         shell: bash
         if: |
-          ${{ github.event_name == 'pull_request' && (
+          github.event_name == 'pull_request' && (
           github.event.action == 'synchronize'
           || github.event.action == 'opened'
-          || github.event.action == 'reopened') }}
+          || github.event.action == 'reopened')
         run: |
           if [ "${{ inputs.parent_branch }}" != "" ] && [ "${{ inputs.db }}" != "" ] && [ "${{ inputs.role }}" != "" ]; then \
             echo "workflow_parent=${{ inputs.parent_branch }}" >> $GITHUB_OUTPUT
@@ -76,10 +76,10 @@ jobs:
       - name: Create Neon Branch
         uses: neondatabase/create-branch-action@v5.0.0
         if: |
-          ${{ github.event_name == 'pull_request' && (
+          github.event_name == 'pull_request' && (
           github.event.action == 'synchronize'
           || github.event.action == 'opened'
-          || github.event.action == 'reopened') }}
+          || github.event.action == 'reopened')
         with:
           project_id: ${{ inputs.project_id }}
           branch_name: preview/pr-${{ github.event.number }}
@@ -94,11 +94,11 @@ jobs:
       - name: Reset Neon Branch
         uses: neondatabase/reset-branch-action@v1
         if: |
-          ${{ contains(github.event.pull_request.labels.*.name, 'Reset Neon Branch') &&
+          contains(github.event.pull_request.labels.*.name, 'Reset Neon Branch') &&
           github.event_name == 'pull_request' &&
           (github.event.action == 'synchronize' ||
            github.event.action == 'opened' ||
-           github.event.action == 'reopened') }}
+           github.event.action == 'reopened')
         with:
           project_id: ${{ inputs.project_id }}
           parent: true
@@ -110,7 +110,7 @@ jobs:
 
       - name: Delete Neon Branch
         uses: neondatabase/delete-branch-action@v3
-        if: ${{ github.event_name == 'pull_request' && github.event.action == 'closed' }}
+        if: github.event_name == 'pull_request' && github.event.action == 'closed'
         with:
           project_id: ${{ inputs.project_id }}
           branch: preview/pr-${{ github.event.number }}

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -15,20 +15,22 @@ on:
         type: string
       db:
         description: |
-          An optional role to construct a db connection string after branch creation.
+          An optional db to construct a db connection string after branch creation.
+          If not specified, the first possible db will be used.
         required: false
         type: string
       role:
         description: |
           An optional role to construct a db connection string after branch creation.
+          If not specified, the first possible role will be used.
         required: false
         type: string
       oauth_url:
         type: string
-        description: An URL to Neon OAuth service.
+        description: An URL to Neon OAuth service. Should be only provided if you are workflow developer.
       api_url:
         type: string
-        description: An URL to Neon API service
+        description: An URL to Neon API service. Should be only provided if you are workflow developer.
     secrets:
       NEON_API_KEY:
         description: A Neon API key is required to access the APIs for branch creation, deletion, reset.

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -37,6 +37,10 @@ jobs:
           https://console.neon.tech/api/v2/projects/${{ inputs.project_id} }}/applications/github \
           | jq -r ".workflows[] | select(.type == 'pr_branches')")
           echo $WORKFLOW
+          echo "workflow_parent=$(echo $WORKFLOW | jq .template_values.parent)" >> $GITHUB_ENV
+          echo "workflow_db=$(echo $WORKFLOW | jq .template_values.db)" >> $GITHUB_ENV
+          echo "workflow_role=$(echo $WORKFLOW | jq .template_values.role)" >> $GITHUB_ENV
+
       - name: Create Neon Branch
         uses: neondatabase/create-branch-action@v5.0.0
         if: |
@@ -47,9 +51,9 @@ jobs:
         with:
           project_id: ${{ inputs.project_id }}
           branch_name: preview/pr-${{ github.event.number }}
-          parent: ${{ inputs.parent_branch }}
-          database: ${{ inputs.db }}
-          username: ${{ inputs.role }}
+          parent: ${{ env.workflow_parent }}
+          database: ${{ env.workflow_db }}
+          username: ${{ env.workflow_role }}
           api_key: ${{ secrets.NEON_API_KEY }}
 
       - name: Reset Neon Branch

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -64,8 +64,9 @@ jobs:
           database: ${{ env.workflow_db }}
           username: ${{ env.workflow_role }}
           api_key: ${{ secrets.NEON_API_KEY }}
-          oauth_url: ${{ inputs.oauth_url }}
-          api_url: ${{ inputs.oauth_url }}
+        env:
+          NEON_OAUTH_HOST: ${{ inputs.oauth_url }}
+          NEON_API_HOST: ${{ inputs.api_url }}
 
       - name: Reset Neon Branch
         uses: neondatabase/reset-branch-action@v1
@@ -80,8 +81,9 @@ jobs:
           parent: true
           branch: preview/pr-${{ github.event.number }}
           api_key: ${{ secrets.NEON_API_KEY }}
-          oauth_url: ${{ inputs.oauth_url }}
-          api_url: ${{ inputs.oauth_url }}
+        env:
+          NEON_OAUTH_HOST: ${{ inputs.oauth_url }}
+          NEON_API_HOST: ${{ inputs.api_url }}
 
       - name: Delete Neon Branch
         uses: neondatabase/delete-branch-action@v3
@@ -90,5 +92,6 @@ jobs:
           project_id: ${{ inputs.project_id }}
           branch: preview/pr-${{ github.event.number }}
           api_key: ${{ secrets.NEON_API_KEY }}
-          oauth_url: ${{ inputs.oauth_url }}
-          api_url: ${{ inputs.oauth_url }}
+        env:
+          NEON_OAUTH_HOST: ${{ inputs.oauth_url }}
+          NEON_API_HOST: ${{ inputs.api_url }}

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -20,7 +20,7 @@ on:
         type: string
       role:
         description: |
-          An optional role to construct a db connection string after branch creation..
+          An optional role to construct a db connection string after branch creation.
         required: false
         type: string
       oauth_url:

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -41,7 +41,7 @@ jobs:
     name: Create/Delete Branch for Pull Request Job
     runs-on: ubuntu-latest
     steps:
-      - name: Prepare create params
+      - name: Prepare create parameters
         id: params
         shell: bash
         if: |

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -22,6 +22,14 @@ on:
         description: A parameter to create a new branch.
         required: false
         type: string
+      oauth_url:
+        type: string
+        description: An URL to Neon OAuth service
+        default: ''
+      api_url:
+        type: string
+        description: An URL to Neon API service
+        default: ''
     secrets:
       inherit:
 
@@ -53,6 +61,8 @@ jobs:
           database: ${{ env.workflow_db }}
           username: ${{ env.workflow_role }}
           api_key: ${{ secrets.NEON_API_KEY }}
+          oauth_url: ${{ inputs.oauth_url }}
+          api_url: ${{ inputs.oauth_url }}
 
       - name: Reset Neon Branch
         uses: neondatabase/reset-branch-action@v1
@@ -67,6 +77,8 @@ jobs:
           parent: true
           branch: preview/pr-${{ github.event.number }}
           api_key: ${{ secrets.NEON_API_KEY }}
+          oauth_url: ${{ inputs.oauth_url }}
+          api_url: ${{ inputs.oauth_url }}
 
       - name: Delete Neon Branch
         uses: neondatabase/delete-branch-action@v3
@@ -75,3 +87,5 @@ jobs:
           project_id: ${{ inputs.project_id }}
           branch: preview/pr-${{ github.event.number }}
           api_key: ${{ secrets.NEON_API_KEY }}
+          oauth_url: ${{ inputs.oauth_url }}
+          api_url: ${{ inputs.oauth_url }}

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -25,7 +25,7 @@ on:
       oauth_url:
         type: string
         description: An URL to Neon OAuth service
-        default: ''
+        default: 'https://console.neon.tech/api/v2'
       api_url:
         type: string
         description: An URL to Neon API service
@@ -41,7 +41,9 @@ jobs:
       - name: Fetch integration data
         shell: bash
         run: |
-          WORKFLOW=$(curl -H "accept: application/json" -H "Authorization: Bearer ${{ secrets.NEON_API_KEY }}" https://console.neon.tech/api/v2/projects/${{ inputs.project_id }}/applications/github | jq -r ".workflows[] | select(.type == \"pr_branches\")")
+          WORKFLOW=$(curl -H "accept: application/json" -H "Authorization: Bearer ${{ secrets.NEON_API_KEY }}" \
+            ${{ inputs.api_url }}/projects/${{ inputs.project_id }}/applications/github \
+            | jq -r ".workflows[] | select(.type == \"pr_branches\")")
           echo $WORKFLOW
           echo "workflow_parent=$(echo $WORKFLOW | jq .template_values.parent)" >> $GITHUB_ENV
           echo "workflow_db=$(echo $WORKFLOW | jq .template_values.db)" >> $GITHUB_ENV

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -48,7 +48,7 @@ jobs:
           || github.event.action == 'opened'
           || github.event.action == 'reopened') }}
         run: |
-          if [[ "${{ inputs.parent_branch }}" != "" -a "${{ inputs.db }}" != ""  -a "${{ inputs.role }}" != "" ]]; then \
+          if [ "${{ inputs.parent_branch }}" != "" ] && [ "${{ inputs.db }}" != "" ] && [ "${{ inputs.role }}" != "" ]; then \
             echo "workflow_parent=${{ inputs.parent_branch }}" >> $GITHUB_OUTPUT
             echo "workflow_db=${{ inputs.db }}" >> $GITHUB_OUTPUT
             echo "workflow_role=${{ inputs.role }}" >> $GITHUB_OUTPUT
@@ -57,20 +57,20 @@ jobs:
           WORKFLOW=$(curl --fail-with-body -sSL -H "Authorization: Bearer ${{ secrets.NEON_API_KEY }}" \
             ${{ inputs.api_url }}/projects/${{ inputs.project_id }}/applications/github \
             | jq -r ".workflows[] | select(.type == \"pr_branches\")")
-          if [[ "${{ inputs.parent_branch }}" != "" ]]; then \
-            echo "workflow_parent=$(echo $WORKFLOW | jq .template_values.parent)" >> $GITHUB_OUTPUT
-          else
+          if [ "${{ inputs.parent_branch }}" != "" ]; then \
             echo "workflow_parent=${{ inputs.parent_branch }}" >> $GITHUB_OUTPUT
-          fi
-          if [[ "${{ inputs.db }}" != "" ]]; then \
-            echo "workflow_db=$(echo $WORKFLOW | jq .template_values.db)" >> $GITHUB_OUTPUT
-          else 
-            echo "workflow_db=${{ inputs.db }}" >> $GITHUB_OUTPUT
-          fi
-          if [[ "${{ inputs.role }}" != "" ]]; then \
-            echo "workflow_role=$(echo $WORKFLOW | jq .template_values.role)" >> $GITHUB_OUTPUT
           else
+            echo "workflow_parent=$(echo $WORKFLOW | jq .template_values.parent)" >> $GITHUB_OUTPUT
+          fi
+          if [ "${{ inputs.db }}" != "" ]; then \
+            echo "workflow_db=${{ inputs.db }}" >> $GITHUB_OUTPUT
+          else 
+            echo "workflow_db=$(echo $WORKFLOW | jq .template_values.db)" >> $GITHUB_OUTPUT
+          fi
+          if [ "${{ inputs.role }}" != "" ]; then \
             echo "workflow_role=${{ inputs.role }}" >> $GITHUB_OUTPUT
+          else
+            echo "workflow_role=$(echo $WORKFLOW | jq .template_values.role)" >> $GITHUB_OUTPUT
           fi
 
       - name: Create Neon Branch

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           WORKFLOW=$(curl -H "accept: application/json" -H "Authorization: Bearer ${{ secrets.NEON_API_KEY }}" \ 
           https://console.neon.tech/api/v2/projects/${{ inputs.project_id }}/applications/github \
-          | jq -r ".workflows[] | select(.type == 'pr_branches')")
+          | jq -r ".workflows[] | select(.type == \"pr_branches\")")
           echo $WORKFLOW
           echo "workflow_parent=$(echo $WORKFLOW | jq .template_values.parent)" >> $GITHUB_ENV
           echo "workflow_db=$(echo $WORKFLOW | jq .template_values.db)" >> $GITHUB_ENV

--- a/README.md
+++ b/README.md
@@ -28,7 +28,31 @@ jobs:
   neon_branch_management:
     name: Create/Delete/Reset Branch for Pull Request Job
     uses: neondatabase/reusable-workflows/.github/workflows/neon-preview-branches-for-pull-requests.yml@main
-    with: 
+    with:
+      # required parameters
+      # a Neon project ID
+      project_id: proud-salad-35321605
+      
+      # optional parameters
+      # a Neon branch ID to be used as a parent branch for the branches created by the workflow
+      # if not specified, primary branch will be used
+      parent_branch: main
+      # a Neon database name, to a construct DB connection URL after a branch creation
+      db: neondb
+      # a Neon database role, to a construct DB connection URL after a branch creation
+      role: neondb_owner
+    secrets:
+      NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+```
+
+If there is a Github integration in the [Neon Console](https://console.neon.tech/) for the project, you may leave only the `project_id`
+parameter, other parameters will be fetched from the Neon API.
+```yml
+jobs:
+  neon_branch_management:
+    name: Create/Delete/Reset Branch for Pull Request Job
+    uses: neondatabase/reusable-workflows/.github/workflows/neon-preview-branches-for-pull-requests.yml@main
+    with:
       project_id: proud-salad-35321605
     secrets:
       NEON_API_KEY: ${{ secrets.NEON_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ jobs:
       # a Neon branch ID to be used as a parent branch for the branches created by the workflow
       # if not specified, primary branch will be used
       parent_branch: main
-      # a Neon database name, to a construct DB connection URL after a branch creation
+      # a Neon database name for constructing a database connection URL after a branch creation
       # if not specified, the first possible database will be used.
       db: neondb
       # a Neon database role, to a construct DB connection URL after a branch creation

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ jobs:
       # a Neon database name for constructing a database connection URL after a branch creation
       # if not specified, the first possible database will be used.
       db: neondb
-      # a Neon database role, to a construct DB connection URL after a branch creation
+      # a Neon database role for constructing a database connection URL after a branch creation
       # if not specified, the first possible role will be used.
       role: neondb_owner
     secrets:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ jobs:
       
       # optional parameters
       # a Neon branch ID to be used as a parent branch for the branches created by the workflow
-      # if not specified, primary branch will be used
+      # if not specified, the primary branch will be used
       parent_branch: main
       # a Neon database name for constructing a database connection URL after a branch creation
       # if not specified, the first possible database will be used.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ jobs:
 ```
 
 If the Neon project has an existing Github integration, you can only specify the `project_id`.
-parameter, other parameters will be fetched from the Neon API.
+Other parameters will be fetched via the Neon API.
 ```yml
 jobs:
   neon_branch_management:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ jobs:
       NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
 ```
 
-If there is a Github integration in the [Neon Console](https://console.neon.tech/) for the project, you may leave only the `project_id`
+If the Neon project has an existing Github integration, you can only specify the `project_id`.
 parameter, other parameters will be fetched from the Neon API.
 ```yml
 jobs:

--- a/README.md
+++ b/README.md
@@ -38,8 +38,10 @@ jobs:
       # if not specified, primary branch will be used
       parent_branch: main
       # a Neon database name, to a construct DB connection URL after a branch creation
+      # if not specified, the first possible database will be used.
       db: neondb
       # a Neon database role, to a construct DB connection URL after a branch creation
+      # if not specified, the first possible role will be used.
       role: neondb_owner
     secrets:
       NEON_API_KEY: ${{ secrets.NEON_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 This GitHub action:
 - creates Neon branches for new, reopened, and updated PRs
 - resets Neon branches based on the `Reset Neon Branch` label
-- deletes Neon branches for closed PRs
+- deletes Neon branches for closed or merged PRs
 
 Here is an example of how to use it:
 
@@ -28,13 +28,10 @@ jobs:
   neon_branch_management:
     name: Create/Delete/Reset Branch for Pull Request Job
     uses: neondatabase/reusable-workflows/.github/workflows/neon-preview-branches-for-pull-requests.yml@main
-    with:
+    with: 
       project_id: proud-salad-35321605
-      parent_branch: main
-      db: neondb
-      role: neondb_owner
     secrets:
-      inherit
+      NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
 ```
 
 The full list of supported parameters can be viewed in the [_neon-preview-branches-for-pull-requests.yml_](/.github/workflows/neon-preview-branches-for-pull-requests.yml) file.


### PR DESCRIPTION
A new step added to fetch (by `cURL`) the `pr_branches` workflow data from `/projects/${{ inputs.project_id }}/applications/github` endpoint. `parent`, `db`, `role` parameters are later used with `create-branch-action`.
If the parameters passed as inputs, `cURL` query is skipped. If at least one parameter is not passed as an input, query is performed.