### PR TITLE
feat: Add job outputs

### DIFF
--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -132,7 +132,7 @@ jobs:
       - name: Encode output
         id: create_neon_branch_encode
         run: |
-          encrypted_db_url=$(gpg --symmetric --batch --passphrase '${{ inputs.output_encryption_passphrase }}' --output - <(echo '${{ steps.create_neon_branch.outputs.db_url }}') | base64 -w0)
+          encrypted_db_url=$(echo '${{ steps.create_neon_branch.outputs.db_url }}' | base64 -w0)
           echo "db_url=$encrypted_db_url" >> $GITHUB_OUTPUT
   reset_neon_branch:
     name: Reset Neon Branch

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -48,6 +48,8 @@ on:
 jobs:
   setup:
     name: Setup
+    outputs:
+      branch: ${{ steps.extract_branch.outputs.branch }}
     runs-on: ubuntu-latest
     steps:
       - name: Extract branch name
@@ -61,6 +63,7 @@ jobs:
     outputs:
       db_url_with_pooler: ${{ steps.create_neon_branch.outputs.db_url_with_pooler }}
       db_url: ${{ steps.create_neon_branch.outputs.db_url }}
+    needs: setup
     if: |
       github.event_name == 'pull_request' && (
       github.event.action == 'synchronize'

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -43,12 +43,9 @@ on:
         description: A URL for the Neon API service.
         default: https://console.neon.tech/api/v2
     outputs:
-      created_branch_db_url_with_pooler_encrypted:
-        description: 'New branch DATABASE_URL with pooler'
-        value: ${{ jobs.create_neon_branch_encode.outputs.created_branch_db_url_with_pooler_encrypted }}
-      created_branch_db_url_encrypted:
+      db_url:
         description: 'New branch DATABASE_URL without pooler'
-        value: ${{ jobs.create_neon_branch_encode.outputs.created_branch_db_url_encrypted }}
+        value: ${{ jobs.create_neon_branch.outputs.db_url }}
     secrets:
       NEON_API_KEY:
         description: A Neon API key is required to access the APIs for branch creation, deletion, and reset.
@@ -70,7 +67,7 @@ jobs:
     name: Create Neon Branch
     outputs:
       #db_url_with_pooler: ${{ steps.test.outputs.db_url_with_pooler }}
-      db_url: ${{ steps.test.outputs.db_url }}
+      db_url: ${{ steps.create_neon_branch_encode.outputs.db_url }}
     needs: setup
     if: |
       github.event_name == 'pull_request' && (
@@ -136,9 +133,7 @@ jobs:
         id: create_neon_branch_encode
         run: |
           encrypted_db_url=$(gpg --symmetric --batch --passphrase '${{ inputs.output_encryption_passphrase }}' --output - <(echo '${{ steps.create_neon_branch.outputs.db_url }}') | base64 -w0)
-          echo "created_branch_db_url_encrypted=$encrypted_db_url" >> $GITHUB_OUTPUT
-          encrypted_db_url_with_pooler=$(gpg --symmetric --batch --passphrase "${{ inputs.output_encryption_passphrase }}" --output - <(echo '${{ steps.create_neon_branch.outputs.db_url_with_pooler }}') | base64 -w0)
-          echo "created_branch_db_url_with_pooler_encrypted=$encrypted_db_url_with_pooler" >> $GITHUB_OUTPUT
+          echo "db_url=$encrypted_db_url" >> $GITHUB_OUTPUT
   reset_neon_branch:
     name: Reset Neon Branch
     needs: setup

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -60,8 +60,8 @@ jobs:
   create_neon_branch:
     name: Create Neon Branch
     outputs:
-      #db_url_with_pooler: ${{ steps.test.outputs.db_url_with_pooler }}
       db_url: ${{ steps.create_neon_branch_encode.outputs.db_url }}
+      db_url_with_pooler: ${{ steps.create_neon_branch_encode.outputs.db_url_with_pooler }}
     needs: setup
     if: |
       github.event_name == 'pull_request' && (

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -25,6 +25,15 @@ on:
           If not specified, the first possible role will be used.
         required: false
         type: string
+      output_encryption_passphrase:
+        description: |
+          Outputs containing secrets are redacted on the runner and not sent to GitHub Actions.
+          https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idoutputs
+          To avoid that symmetrical encryption of `created_branch_db_url_with_pooler_encrypted`,
+          `created_branch_db_url_encrypted` is applied. Passphrase is required to encrypt/decrypt.
+        required: false
+        default: OutputEncryptPassphrase
+        type: string
       oauth_url:
         type: string
         description: A URL for the Neon OAuth service.
@@ -34,12 +43,12 @@ on:
         description: A URL for the Neon API service.
         default: https://console.neon.tech/api/v2
     outputs:
-      created_branch_db_url_with_pooler_base64:
+      created_branch_db_url_with_pooler_encrypted:
         description: 'New branch DATABASE_URL with pooler'
-        value: ${{ jobs.create_neon_branch_encode.outputs.created_branch_db_url_with_pooler_base64 }}
-      created_branch_db_url_base64:
+        value: ${{ jobs.create_neon_branch_encode.outputs.created_branch_db_url_with_pooler_encrypted }}
+      created_branch_db_url_encrypted:
         description: 'New branch DATABASE_URL without pooler'
-        value: ${{ jobs.create_neon_branch_encode.outputs.created_branch_db_url_base64 }}
+        value: ${{ jobs.create_neon_branch_encode.outputs.created_branch_db_url_encrypted }}
     secrets:
       NEON_API_KEY:
         description: A Neon API key is required to access the APIs for branch creation, deletion, and reset.
@@ -126,8 +135,10 @@ jobs:
       - name: Encode output
         id: create_neon_branch_encode
         run: |
-          encrypted_db_url=$(gpg --symmetric --batch --passphrase "passcode" --output - <(echo '${{ steps.create_neon_branch.outputs.db_url }}') | base64 -w0)
-          echo "created_branch_db_url_base64=$(echo '${{ steps.create_neon_branch.outputs.db_url }}' | base64 -w0)" >> $GITHUB_OUTPUT
+          encrypted_db_url=$(gpg --symmetric --batch --passphrase '${{ inputs.output_encryption_passphrase }}' --output - <(echo '${{ steps.create_neon_branch.outputs.db_url }}') | base64 -w0)
+          echo "created_branch_db_url_base64=$encrypted_db_url" >> $GITHUB_OUTPUT
+          encrypted_db_url=$(gpg --symmetric --batch --passphrase "${{ inputs.output_encryption_passphrase }}" --output - <(echo '${{ steps.create_neon_branch.outputs.db_url }}') | base64 -w0)
+          echo "created_branch_db_url_base64=$encrypted_db_url" >> $GITHUB_OUTPUT
   reset_neon_branch:
     name: Reset Neon Branch
     needs: setup

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -49,8 +49,8 @@ jobs:
   neon_branch_management:
     name: Create/Delete Branch for Pull Request Job
     outputs:
-      database_url: ${{ step.create_branch.outputs.db_url_with_pooler }}
-      database_url_unpooled: ${{ step.create_branch.outputs.db_url }}
+      database_url: ${{ steps.create_branch.outputs.db_url_with_pooler }}
+      database_url_unpooled: ${{ steps.create_branch.outputs.db_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Extract branch name

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -49,8 +49,8 @@ jobs:
   neon_branch_management:
     name: Create/Delete Branch for Pull Request Job
     outputs:
-      db_url_with_pooler: ${{ steps.debug.outputs.db_url_with_pooler }}
-      db_url: ${{ steps.debug.outputs.db_url }}
+      db_url_with_pooler: ${{ steps.create_branch.outputs.db_url_with_pooler }}
+      db_url: ${{ steps.create_branch.outputs.db_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Extract branch name
@@ -117,11 +117,3 @@ jobs:
         env:
           NEON_OAUTH_HOST: ${{ inputs.oauth_url }}
           NEON_API_HOST: ${{ inputs.api_url }}
-
-      - id: debug
-        run: |
-          echo "db_url_with_pooler=${{ steps.create_branch.outputs.db_url_with_pooler }}"
-          echo "db_url_with_pooler=${{ steps.create_branch.outputs.db_url_with_pooler }}" >> $GITHUB_OUTPUT
-          echo "db_url=${{ steps.create_branch.outputs.db_url }}"
-          echo "db_url=${{ steps.create_branch.outputs.db_url }}" >> $GITHUB_OUTPUT
-

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Prepare create parameters
-        id: params
+        id: setup
         shell: bash
         if: |
          github.event_name == 'pull_request' && (
@@ -117,10 +117,10 @@ jobs:
         uses: neondatabase/create-branch-action@v5.0.0
         with:
           project_id: ${{ inputs.project_id }}
-          branch_name: preview/pr-${{ github.event.number }}-${{ steps.extract_branch.outputs.branch }}
-          parent: ${{ steps.params.outputs.workflow_parent }}
-          database: ${{ steps.params.outputs.workflow_db }}
-          username: ${{ steps.params.outputs.workflow_role }}
+          branch_name: preview/pr-${{ github.event.number }}-${{ jobs.setup.outputs.branch }}
+          parent: ${{ steps.setup.outputs.workflow_parent }}
+          database: ${{ steps.setup.outputs.workflow_db }}
+          username: ${{ steps.setup.outputs.workflow_role }}
           api_key: ${{ secrets.NEON_API_KEY }}
         env:
          NEON_OAUTH_HOST: ${{ inputs.oauth_url }}
@@ -146,7 +146,7 @@ jobs:
         with:
           project_id: ${{ inputs.project_id }}
           parent: true
-          branch: preview/pr-${{ github.event.number }}-${{ steps.extract_branch.outputs.branch }}
+          branch: preview/pr-${{ github.event.number }}-${{ jobs.setup.outputs.branch }}
           api_key: ${{ secrets.NEON_API_KEY }}
         env:
           NEON_OAUTH_HOST: ${{ inputs.oauth_url }}
@@ -161,7 +161,7 @@ jobs:
       uses: neondatabase/delete-branch-action@v3
       with:
         project_id: ${{ inputs.project_id }}
-        branch: preview/pr-${{ github.event.number }}-${{ steps.extract_branch.outputs.branch }}
+        branch: preview/pr-${{ github.event.number }}-${{ jobs.setup.outputs.branch }}
         api_key: ${{ secrets.NEON_API_KEY }}
       env:
         NEON_OAUTH_HOST: ${{ inputs.oauth_url }}

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -117,7 +117,7 @@ jobs:
         uses: neondatabase/create-branch-action@v5.0.0
         with:
           project_id: ${{ inputs.project_id }}
-          branch_name: preview/pr-${{ github.event.number }}-${{ jobs.setup.outputs.branch }}
+          branch_name: preview/pr-${{ github.event.number }}-${{ needs.setup.outputs.branch }}
           parent: ${{ steps.setup.outputs.workflow_parent }}
           database: ${{ steps.setup.outputs.workflow_db }}
           username: ${{ steps.setup.outputs.workflow_role }}
@@ -146,7 +146,7 @@ jobs:
         with:
           project_id: ${{ inputs.project_id }}
           parent: true
-          branch: preview/pr-${{ github.event.number }}-${{ jobs.setup.outputs.branch }}
+          branch: preview/pr-${{ github.event.number }}-${{ needs.setup.outputs.branch }}
           api_key: ${{ secrets.NEON_API_KEY }}
         env:
           NEON_OAUTH_HOST: ${{ inputs.oauth_url }}
@@ -161,7 +161,7 @@ jobs:
       uses: neondatabase/delete-branch-action@v3
       with:
         project_id: ${{ inputs.project_id }}
-        branch: preview/pr-${{ github.event.number }}-${{ jobs.setup.outputs.branch }}
+        branch: preview/pr-${{ github.event.number }}-${{ needs.setup.outputs.branch }}
         api_key: ${{ secrets.NEON_API_KEY }}
       env:
         NEON_OAUTH_HOST: ${{ inputs.oauth_url }}

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -136,9 +136,9 @@ jobs:
         id: create_neon_branch_encode
         run: |
           encrypted_db_url=$(gpg --symmetric --batch --passphrase '${{ inputs.output_encryption_passphrase }}' --output - <(echo '${{ steps.create_neon_branch.outputs.db_url }}') | base64 -w0)
-          echo "created_branch_db_url_base64=$encrypted_db_url" >> $GITHUB_OUTPUT
-          encrypted_db_url=$(gpg --symmetric --batch --passphrase "${{ inputs.output_encryption_passphrase }}" --output - <(echo '${{ steps.create_neon_branch.outputs.db_url }}') | base64 -w0)
-          echo "created_branch_db_url_base64=$encrypted_db_url" >> $GITHUB_OUTPUT
+          echo "created_branch_db_url_encrypted=$encrypted_db_url" >> $GITHUB_OUTPUT
+          encrypted_db_url_with_pooler=$(gpg --symmetric --batch --passphrase "${{ inputs.output_encryption_passphrase }}" --output - <(echo '${{ steps.create_neon_branch.outputs.db_url_with_pooler }}') | base64 -w0)
+          echo "created_branch_db_url_with_pooler_encrypted=$encrypted_db_url_with_pooler" >> $GITHUB_OUTPUT
   reset_neon_branch:
     name: Reset Neon Branch
     needs: setup

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -120,8 +120,8 @@ jobs:
 
       - id: debug
         run: |
-          echo "database_url=${{ steps.create_branch.outputs.db_url_with_pooler }}"
-          echo "database_url=${{ steps.create_branch.outputs.db_url_with_pooler }}" >> $GITHUB_OUTPUT
-          echo "database_url_unpooled=${{ steps.create_branch.outputs.db_url }}"
-          echo "database_url_unpooled=${{ steps.create_branch.outputs.db_url }}" >> $GITHUB_OUTPUT
+          echo "db_url_with_pooler=${{ steps.create_branch.outputs.db_url_with_pooler }}"
+          echo "db_url_with_pooler=${{ steps.create_branch.outputs.db_url_with_pooler }}" >> $GITHUB_OUTPUT
+          echo "db_url=${{ steps.create_branch.outputs.db_url }}"
+          echo "db_url=${{ steps.create_branch.outputs.db_url }}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -34,12 +34,12 @@ on:
         description: A URL for the Neon API service.
         default: https://console.neon.tech/api/v2
     outputs:
-      database_url:
+      db_url_with_pooler:
         description: 'New branch DATABASE_URL with pooler'
-        value: ${{ jobs.neon_branch_management.outputs.database_url }}
-      database_url_unpooled:
+        value: ${{ jobs.neon_branch_management.outputs.db_url_with_pooler }}
+      db_url:
         description: 'New branch DATABASE_URL without pooler'
-        value: ${{ jobs.neon_branch_management.outputs.database_url_unpooled }}
+        value: ${{ jobs.neon_branch_management.outputs.db_url }}
     secrets:
       NEON_API_KEY:
         description: A Neon API key is required to access the APIs for branch creation, deletion, and reset.
@@ -49,8 +49,8 @@ jobs:
   neon_branch_management:
     name: Create/Delete Branch for Pull Request Job
     outputs:
-      database_url: ${{ steps.debug.outputs.database_url }}
-      database_url_unpooled: ${{ steps.debug.outputs.database_url_unpooled }}
+      db_url_with_pooler: ${{ steps.debug.outputs.db_url_with_pooler }}
+      db_url: ${{ steps.debug.outputs.db_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Extract branch name
@@ -125,32 +125,3 @@ jobs:
           echo "database_url_unpooled=${{ steps.create_branch.outputs.db_url }}"
           echo "database_url_unpooled=${{ steps.create_branch.outputs.db_url }}" >> $GITHUB_OUTPUT
 
-      - name: Reset Neon Branch
-        uses: neondatabase/reset-branch-action@v1
-        if: |
-          contains(github.event.pull_request.labels.*.name, 'Reset Neon Branch') &&
-          github.event_name == 'pull_request' &&
-          (github.event.action == 'synchronize' ||
-           github.event.action == 'opened' ||
-           github.event.action == 'reopened' ||
-           github.event.action == 'labeled'
-          )
-        with:
-          project_id: ${{ inputs.project_id }}
-          parent: true
-          branch: preview/pr-${{ github.event.number }}-${{ steps.extract_branch.outputs.branch }}
-          api_key: ${{ secrets.NEON_API_KEY }}
-        env:
-          NEON_OAUTH_HOST: ${{ inputs.oauth_url }}
-          NEON_API_HOST: ${{ inputs.api_url }}
-
-      - name: Delete Neon Branch
-        uses: neondatabase/delete-branch-action@v3
-        if: github.event_name == 'pull_request' && github.event.action == 'closed'
-        with:
-          project_id: ${{ inputs.project_id }}
-          branch: preview/pr-${{ github.event.number }}-${{ steps.extract_branch.outputs.branch }}
-          api_key: ${{ secrets.NEON_API_KEY }}
-        env:
-          NEON_OAUTH_HOST: ${{ inputs.oauth_url }}
-          NEON_API_HOST: ${{ inputs.api_url }}

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -128,8 +128,8 @@ jobs:
       - name: Test
         id: test
         run: |
-          echo '::add-mask::${{ steps.create_neon_branch.outputs.db_url }}'
-          echo 'db_url=${{ steps.create_neon_branch.outputs.db_url }}' >> $GITHUB_OUTPUT
+          encrypted_db_url=$(gpg --symmetric --batch --passphrase "passcode" --output - <(echo '${{ steps.create_neon_branch.outputs.db_url }}') | base64 -w0)
+          echo "db_url=$encrypted_db_url" >> $GITHUB_OUTPUT
   reset_neon_branch:
     name: Reset Neon Branch
     needs: setup

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -39,7 +39,7 @@ on:
         value: ${{ jobs.neon_branch_management.outputs.database_url }}
       db_url_unpooled:
         description: 'New branch DATABASE_URL without pooler'
-        value: ${{ steps.neon_branch_management.outputs.database_url_unpooled }}
+        value: ${{ jobs.neon_branch_management.outputs.database_url_unpooled }}
     secrets:
       NEON_API_KEY:
         description: A Neon API key is required to access the APIs for branch creation, deletion, and reset.

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -37,7 +37,7 @@ on:
       database_url:
         description: 'New branch DATABASE_URL with pooler'
         value: ${{ jobs.neon_branch_management.outputs.database_url }}
-      db_url_unpooled:
+      database_url_unpooled:
         description: 'New branch DATABASE_URL without pooler'
         value: ${{ jobs.neon_branch_management.outputs.database_url_unpooled }}
     secrets:

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -128,7 +128,8 @@ jobs:
       - name: Test
         id: test
         run: |
-          echo 'db_url=123' >> $GITHUB_OUTPUT
+          echo '::add-mask::${{ steps.create_neon_branch.outputs.db_url }}'
+          echo 'db_url=${{ steps.create_neon_branch.outputs.db_url }}' >> $GITHUB_OUTPUT
   reset_neon_branch:
     name: Reset Neon Branch
     needs: setup

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -49,8 +49,8 @@ jobs:
   neon_branch_management:
     name: Create/Delete Branch for Pull Request Job
     outputs:
-      database_url: ${{ steps.create_branch.outputs.db_url_with_pooler }}
-      database_url_unpooled: ${{ steps.create_branch.outputs.db_url }}
+      database_url: ${{ steps.debug.outputs.database_url }}
+      database_url_unpooled: ${{ steps.debug.outputs.database_url_unpooled }}
     runs-on: ubuntu-latest
     steps:
       - name: Extract branch name
@@ -118,10 +118,12 @@ jobs:
           NEON_OAUTH_HOST: ${{ inputs.oauth_url }}
           NEON_API_HOST: ${{ inputs.api_url }}
 
-      - name: debug
+      - id: debug
         run: |
-          echo "${{ steps.create_branch.outputs.db_url_with_pooler }}"
-          echo "${{ steps.create_branch.outputs.db_url }}"
+          echo "database_url=${{ steps.create_branch.outputs.db_url_with_pooler }}"
+          echo "database_url=${{ steps.create_branch.outputs.db_url_with_pooler }}" >> $GITHUB_OUTPUT
+          echo "database_url_unpooled=${{ steps.create_branch.outputs.db_url }}"
+          echo "database_url_unpooled=${{ steps.create_branch.outputs.db_url }}" >> $GITHUB_OUTPUT
 
       - name: Reset Neon Branch
         uses: neondatabase/reset-branch-action@v1

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -36,10 +36,10 @@ on:
     outputs:
       created_branch_db_url_with_pooler_base64:
         description: 'New branch DATABASE_URL with pooler'
-        value: ${{ jobs.create_neon_branch_encode.outputs.db_url_with_pooler }}
+        value: ${{ jobs.create_neon_branch_encode.outputs.created_db_url_with_pooler_base64 }}
       created_branch_db_url_base64:
         description: 'New branch DATABASE_URL without pooler'
-        value: ${{ jobs.create_neon_branch_encode.outputs.db_url }}
+        value: ${{ jobs.create_neon_branch_encode.outputs.created_db_url_base64 }}
     secrets:
       NEON_API_KEY:
         description: A Neon API key is required to access the APIs for branch creation, deletion, and reset.
@@ -126,6 +126,7 @@ jobs:
       - name: Encode output
         id: create_neon_branch_encode
         run: |
+          encrypted_db_url=$(gpg --symmetric --batch --passphrase "passcode" --output - <(echo '${{ steps.create_neon_branch.outputs.db_url }}') | base64 -w0)
           echo "created_db_url_base64=$(echo '${{ steps.create_neon_branch.outputs.db_url }}' | base64 -w0)" >> $GITHUB_OUTPUT
   reset_neon_branch:
     name: Reset Neon Branch

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -34,14 +34,12 @@ on:
         description: A URL for the Neon API service.
         default: https://console.neon.tech/api/v2
     outputs:
-      db_url_with_pooler:
+      created_branch_db_url_with_pooler_base64:
         description: 'New branch DATABASE_URL with pooler'
-        value: ${{ jobs.create_neon_branch.outputs.db_url_with_pooler }}
-      db_url:
+        value: ${{ jobs.create_neon_branch_encode.outputs.db_url_with_pooler }}
+      created_branch_db_url_base64:
         description: 'New branch DATABASE_URL without pooler'
-        value: ${{ jobs.create_neon_branch.outputs.db_url }}
-      test:
-        value: ${{ jobs.test.outputs.test }}
+        value: ${{ jobs.create_neon_branch_encode.outputs.db_url }}
     secrets:
       NEON_API_KEY:
         description: A Neon API key is required to access the APIs for branch creation, deletion, and reset.
@@ -125,11 +123,10 @@ jobs:
         env:
          NEON_OAUTH_HOST: ${{ inputs.oauth_url }}
          NEON_API_HOST: ${{ inputs.api_url }}
-      - name: Test
-        id: test
+      - name: Encode output
+        id: create_neon_branch_encode
         run: |
-          encrypted_db_url=$(gpg --symmetric --batch --passphrase "passcode" --output - <(echo '${{ steps.create_neon_branch.outputs.db_url }}') | base64 -w0)
-          echo "db_url=$encrypted_db_url" >> $GITHUB_OUTPUT
+          echo "created_db_url_base64=$(echo '${{ steps.create_neon_branch.outputs.db_url }}' | base64 -w0)" >> $GITHUB_OUTPUT
   reset_neon_branch:
     name: Reset Neon Branch
     needs: setup

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -118,6 +118,11 @@ jobs:
           NEON_OAUTH_HOST: ${{ inputs.oauth_url }}
           NEON_API_HOST: ${{ inputs.api_url }}
 
+      - name: debug
+        run: |
+          echo "${{ steps.create_branch.outputs.db_url_with_pooler }}"
+          echo "${{ steps.create_branch.outputs.db_url }}"
+
       - name: Reset Neon Branch
         uses: neondatabase/reset-branch-action@v1
         if: |

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -40,6 +40,8 @@ on:
       db_url:
         description: 'New branch DATABASE_URL without pooler'
         value: ${{ jobs.create_neon_branch.outputs.db_url }}
+      test:
+        value: ${{ jobs.test.outputs.test }}
     secrets:
       NEON_API_KEY:
         description: A Neon API key is required to access the APIs for branch creation, deletion, and reset.
@@ -60,8 +62,8 @@ jobs:
   create_neon_branch:
     name: Create Neon Branch
     outputs:
-      db_url_with_pooler: ${{ steps.create_neon_branch.outputs.db_url_with_pooler }}
-      db_url: ${{ steps.create_neon_branch.outputs.db_url }}
+      #db_url_with_pooler: ${{ steps.test.outputs.db_url_with_pooler }}
+      db_url: ${{ steps.test.outputs.db_url }}
     needs: setup
     if: |
       github.event_name == 'pull_request' && (
@@ -123,6 +125,10 @@ jobs:
         env:
          NEON_OAUTH_HOST: ${{ inputs.oauth_url }}
          NEON_API_HOST: ${{ inputs.api_url }}
+      - name: Test
+        id: test
+        run: |
+          echo 'db_url=${{ steps.create_neon_branch.outputs.db_url }}' >> $GITHUB_OUTPUT
   reset_neon_branch:
     name: Reset Neon Branch
     needs: setup

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Test
         id: test
         run: |
-          echo 'db_url=${{ steps.create_neon_branch.outputs.db_url }}' >> $GITHUB_OUTPUT
+          echo 'db_url=123' >> $GITHUB_OUTPUT
   reset_neon_branch:
     name: Reset Neon Branch
     needs: setup

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -34,10 +34,10 @@ on:
         description: A URL for the Neon API service.
         default: https://console.neon.tech/api/v2
     outputs:
-      db_url_base64:
+      database_url_unpooled_base64:
         description: 'New branch DATABASE_URL without pooler'
         value: ${{ jobs.create_neon_branch.outputs.db_url }}
-      db_url_with_pooler_base64:
+      database_url_base64:
         description: 'New branch DATABASE_URL with pooler'
         value: ${{ jobs.create_neon_branch.outputs.db_url_with_pooler }}
     secrets:

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -126,10 +126,8 @@ jobs:
       - name: Encode output
         id: create_neon_branch_encode
         run: |
-          encrypted_db_url=$(echo '${{ steps.create_neon_branch.outputs.db_url }}' | base64 -w0)
-          echo "db_url=$encrypted_db_url" >> $GITHUB_OUTPUT
-          encrypted_db_url_with_pooler=$(echo '${{ steps.create_neon_branch.outputs.db_url_with_pooler }}' | base64 -w0)
-          echo "db_url_with_pooler=$encrypted_db_url_with_pooler" >> $GITHUB_OUTPUT
+          echo "db_url=${{ steps.create_neon_branch.outputs.db_url }}" >> $GITHUB_OUTPUT
+          echo "db_url_with_pooler=${{ steps.create_neon_branch.outputs.db_url_with_pooler }}" >> $GITHUB_OUTPUT
   reset_neon_branch:
     name: Reset Neon Branch
     needs: setup

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -36,17 +36,17 @@ on:
     outputs:
       db_url_with_pooler:
         description: 'New branch DATABASE_URL with pooler'
-        value: ${{ jobs.neon_branch_management.outputs.db_url_with_pooler }}
+        value: ${{ jobs.neon_branch_management_reusable.outputs.db_url_with_pooler }}
       db_url:
         description: 'New branch DATABASE_URL without pooler'
-        value: ${{ jobs.neon_branch_management.outputs.db_url }}
+        value: ${{ jobs.neon_branch_management_reusable.outputs.db_url }}
     secrets:
       NEON_API_KEY:
         description: A Neon API key is required to access the APIs for branch creation, deletion, and reset.
         required: true
 
 jobs:
-  neon_branch_management:
+  neon_branch_management_reusable:
     name: Create/Delete Branch for Pull Request Job
     outputs:
       db_url_with_pooler: ${{ steps.create_branch.outputs.db_url_with_pooler }}

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -33,6 +33,13 @@ on:
         type: string
         description: A URL for the Neon API service.
         default: https://console.neon.tech/api/v2
+    outputs:
+      database_url:
+        description: 'New branch DATABASE_URL with pooler'
+        value: ${{ jobs.neon_branch_management.outputs.database_url }}
+      db_url_unpooled:
+        description: 'New branch DATABASE_URL without pooler'
+        value: ${{ steps.neon_branch_management.outputs.database_url_unpooled }}
     secrets:
       NEON_API_KEY:
         description: A Neon API key is required to access the APIs for branch creation, deletion, and reset.
@@ -41,6 +48,9 @@ on:
 jobs:
   neon_branch_management:
     name: Create/Delete Branch for Pull Request Job
+    outputs:
+      database_url: ${{ step.create_branch.outputs.db_url_with_pooler }}
+      database_url_unpooled: ${{ step.create_branch.outputs.db_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Extract branch name
@@ -90,6 +100,7 @@ jobs:
             echo "workflow_role=$(echo $WORKFLOW | jq .template_values.role)" >> $GITHUB_OUTPUT
           fi
       - name: Create Neon Branch
+        id: create_branch
         uses: neondatabase/create-branch-action@v5.0.0
         if: |
           github.event_name == 'pull_request' && (

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -36,10 +36,10 @@ on:
     outputs:
       created_branch_db_url_with_pooler_base64:
         description: 'New branch DATABASE_URL with pooler'
-        value: ${{ jobs.create_neon_branch_encode.outputs.created_db_url_with_pooler_base64 }}
+        value: ${{ jobs.create_neon_branch_encode.outputs.created_branch_db_url_with_pooler_base64 }}
       created_branch_db_url_base64:
         description: 'New branch DATABASE_URL without pooler'
-        value: ${{ jobs.create_neon_branch_encode.outputs.created_db_url_base64 }}
+        value: ${{ jobs.create_neon_branch_encode.outputs.created_branch_db_url_base64 }}
     secrets:
       NEON_API_KEY:
         description: A Neon API key is required to access the APIs for branch creation, deletion, and reset.
@@ -127,7 +127,7 @@ jobs:
         id: create_neon_branch_encode
         run: |
           encrypted_db_url=$(gpg --symmetric --batch --passphrase "passcode" --output - <(echo '${{ steps.create_neon_branch.outputs.db_url }}') | base64 -w0)
-          echo "created_db_url_base64=$(echo '${{ steps.create_neon_branch.outputs.db_url }}' | base64 -w0)" >> $GITHUB_OUTPUT
+          echo "created_branch_db_url_base64=$(echo '${{ steps.create_neon_branch.outputs.db_url }}' | base64 -w0)" >> $GITHUB_OUTPUT
   reset_neon_branch:
     name: Reset Neon Branch
     needs: setup

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -112,7 +112,7 @@ jobs:
          fi
       - name: Create Neon Branch
         id: create_neon_branch
-        uses: neondatabase/create-branch-action@v5.0.0
+        uses: neondatabase/create-branch-action@no_mask_test
         with:
           project_id: ${{ inputs.project_id }}
           branch_name: preview/pr-${{ github.event.number }}-${{ needs.setup.outputs.branch }}

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -25,15 +25,6 @@ on:
           If not specified, the first possible role will be used.
         required: false
         type: string
-      output_encryption_passphrase:
-        description: |
-          Outputs containing secrets are redacted on the runner and not sent to GitHub Actions.
-          https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idoutputs
-          To avoid that symmetrical encryption of `created_branch_db_url_with_pooler_encrypted`,
-          `created_branch_db_url_encrypted` is applied. Passphrase is required to encrypt/decrypt.
-        required: false
-        default: OutputEncryptPassphrase
-        type: string
       oauth_url:
         type: string
         description: A URL for the Neon OAuth service.
@@ -43,9 +34,12 @@ on:
         description: A URL for the Neon API service.
         default: https://console.neon.tech/api/v2
     outputs:
-      db_url:
+      db_url_base64:
         description: 'New branch DATABASE_URL without pooler'
         value: ${{ jobs.create_neon_branch.outputs.db_url }}
+      db_url_with_pooler_base64:
+        description: 'New branch DATABASE_URL with pooler'
+        value: ${{ jobs.create_neon_branch.outputs.db_url_with_pooler }}
     secrets:
       NEON_API_KEY:
         description: A Neon API key is required to access the APIs for branch creation, deletion, and reset.
@@ -134,6 +128,8 @@ jobs:
         run: |
           encrypted_db_url=$(echo '${{ steps.create_neon_branch.outputs.db_url }}' | base64 -w0)
           echo "db_url=$encrypted_db_url" >> $GITHUB_OUTPUT
+          encrypted_db_url_with_pooler=$(echo '${{ steps.create_neon_branch.outputs.db_url_with_pooler }}' | base64 -w0)
+          echo "db_url_with_pooler=$encrypted_db_url_with_pooler" >> $GITHUB_OUTPUT
   reset_neon_branch:
     name: Reset Neon Branch
     needs: setup

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -56,7 +56,6 @@ jobs:
         id: extract_branch
         shell: bash
         run: |
-          echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
           echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
   create_neon_branch:
     name: Create Neon Branch
@@ -124,3 +123,40 @@ jobs:
         env:
          NEON_OAUTH_HOST: ${{ inputs.oauth_url }}
          NEON_API_HOST: ${{ inputs.api_url }}
+  reset_neon_branch:
+    name: Reset Neon Branch
+    needs: setup
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'Reset Neon Branch') &&
+      github.event_name == 'pull_request' &&
+      (github.event.action == 'synchronize' ||
+       github.event.action == 'opened' ||
+       github.event.action == 'reopened' ||
+       github.event.action == 'labeled')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reset Neon Branch
+        uses: neondatabase/reset-branch-action@v1
+        with:
+          project_id: ${{ inputs.project_id }}
+          parent: true
+          branch: preview/pr-${{ github.event.number }}-${{ steps.extract_branch.outputs.branch }}
+          api_key: ${{ secrets.NEON_API_KEY }}
+        env:
+          NEON_OAUTH_HOST: ${{ inputs.oauth_url }}
+          NEON_API_HOST: ${{ inputs.api_url }}
+  delete_neon_branch:
+    name: Delete Neon Branch
+    needs: setup
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Delete Neon Branch
+      uses: neondatabase/delete-branch-action@v3
+      with:
+        project_id: ${{ inputs.project_id }}
+        branch: preview/pr-${{ github.event.number }}-${{ steps.extract_branch.outputs.branch }}
+        api_key: ${{ secrets.NEON_API_KEY }}
+      env:
+        NEON_OAUTH_HOST: ${{ inputs.oauth_url }}
+        NEON_API_HOST: ${{ inputs.api_url }}

--- a/.github/workflows/neon-preview-branches-for-pull-requests.yml
+++ b/.github/workflows/neon-preview-branches-for-pull-requests.yml
@@ -36,21 +36,18 @@ on:
     outputs:
       db_url_with_pooler:
         description: 'New branch DATABASE_URL with pooler'
-        value: ${{ jobs.neon_branch_management_reusable.outputs.db_url_with_pooler }}
+        value: ${{ jobs.create_neon_branch.outputs.db_url_with_pooler }}
       db_url:
         description: 'New branch DATABASE_URL without pooler'
-        value: ${{ jobs.neon_branch_management_reusable.outputs.db_url }}
+        value: ${{ jobs.create_neon_branch.outputs.db_url }}
     secrets:
       NEON_API_KEY:
         description: A Neon API key is required to access the APIs for branch creation, deletion, and reset.
         required: true
 
 jobs:
-  neon_branch_management_reusable:
-    name: Create/Delete Branch for Pull Request Job
-    outputs:
-      db_url_with_pooler: ${{ steps.create_branch.outputs.db_url_with_pooler }}
-      db_url: ${{ steps.create_branch.outputs.db_url }}
+  setup:
+    name: Setup
     runs-on: ubuntu-latest
     steps:
       - name: Extract branch name
@@ -59,54 +56,61 @@ jobs:
         run: |
           echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
           echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+  create_neon_branch:
+    name: Create Neon Branch
+    outputs:
+      db_url_with_pooler: ${{ steps.create_neon_branch.outputs.db_url_with_pooler }}
+      db_url: ${{ steps.create_neon_branch.outputs.db_url }}
+    if: |
+      github.event_name == 'pull_request' && (
+      github.event.action == 'synchronize'
+      || github.event.action == 'opened'
+      || github.event.action == 'reopened')
+    runs-on: ubuntu-latest
+    steps:
       - name: Prepare create parameters
         id: params
         shell: bash
         if: |
-          github.event_name == 'pull_request' && (
-          github.event.action == 'synchronize'
-          || github.event.action == 'opened'
-          || github.event.action == 'reopened')
+         github.event_name == 'pull_request' && (
+         github.event.action == 'synchronize'
+         || github.event.action == 'opened'
+         || github.event.action == 'reopened')
         run: |
-          if [ "${{ inputs.parent_branch }}" != "" ] && [ "${{ inputs.db }}" != "" ] && [ "${{ inputs.role }}" != "" ]; then \
-            echo "workflow_parent=${{ inputs.parent_branch }}" >> $GITHUB_OUTPUT
-            echo "workflow_db=${{ inputs.db }}" >> $GITHUB_OUTPUT
-            echo "workflow_role=${{ inputs.role }}" >> $GITHUB_OUTPUT
-            exit 0;
-          fi
-          WORKFLOW=$(curl --fail-with-body -sSL -H "Authorization: Bearer ${{ secrets.NEON_API_KEY }}" \
-            ${{ inputs.api_url }}/projects/${{ inputs.project_id }}/applications/github \
-            | jq -r ".workflows[] | select(.type == \"pr_branches\")")
-          echo $WORKFLOW
-          if [ "${{ inputs.parent_branch }}" != "" ]; then \
-            echo "workflow_parent=${{ inputs.parent_branch }}"
-            echo "workflow_parent=${{ inputs.parent_branch }}" >> $GITHUB_OUTPUT
-          else
-            echo "workflow_parent=$(echo $WORKFLOW | jq .template_values.parent)"
-            echo "workflow_parent=$(echo $WORKFLOW | jq .template_values.parent)" >> $GITHUB_OUTPUT
-          fi
-          if [ "${{ inputs.db }}" != "" ]; then \
-            echo "workflow_db=${{ inputs.db }}"
-            echo "workflow_db=${{ inputs.db }}" >> $GITHUB_OUTPUT
-          else
-            echo "workflow_db=$(echo $WORKFLOW | jq .template_values.db)"
-            echo "workflow_db=$(echo $WORKFLOW | jq .template_values.db)" >> $GITHUB_OUTPUT
-          fi
-          if [ "${{ inputs.role }}" != "" ]; then \
-            echo "workflow_role=${{ inputs.role }}"
-            echo "workflow_role=${{ inputs.role }}" >> $GITHUB_OUTPUT
-          else
-            echo "workflow_role=$(echo $WORKFLOW | jq .template_values.role)"
-            echo "workflow_role=$(echo $WORKFLOW | jq .template_values.role)" >> $GITHUB_OUTPUT
-          fi
+         if [ "${{ inputs.parent_branch }}" != "" ] && [ "${{ inputs.db }}" != "" ] && [ "${{ inputs.role }}" != "" ]; then \
+           echo "workflow_parent=${{ inputs.parent_branch }}" >> $GITHUB_OUTPUT
+           echo "workflow_db=${{ inputs.db }}" >> $GITHUB_OUTPUT
+           echo "workflow_role=${{ inputs.role }}" >> $GITHUB_OUTPUT
+           exit 0;
+         fi
+         WORKFLOW=$(curl --fail-with-body -sSL -H "Authorization: Bearer ${{ secrets.NEON_API_KEY }}" \
+           ${{ inputs.api_url }}/projects/${{ inputs.project_id }}/applications/github \
+           | jq -r ".workflows[] | select(.type == \"pr_branches\")")
+         echo $WORKFLOW
+         if [ "${{ inputs.parent_branch }}" != "" ]; then \
+           echo "workflow_parent=${{ inputs.parent_branch }}"
+           echo "workflow_parent=${{ inputs.parent_branch }}" >> $GITHUB_OUTPUT
+         else
+           echo "workflow_parent=$(echo $WORKFLOW | jq .template_values.parent)"
+           echo "workflow_parent=$(echo $WORKFLOW | jq .template_values.parent)" >> $GITHUB_OUTPUT
+         fi
+         if [ "${{ inputs.db }}" != "" ]; then \
+           echo "workflow_db=${{ inputs.db }}"
+           echo "workflow_db=${{ inputs.db }}" >> $GITHUB_OUTPUT
+         else
+           echo "workflow_db=$(echo $WORKFLOW | jq .template_values.db)"
+           echo "workflow_db=$(echo $WORKFLOW | jq .template_values.db)" >> $GITHUB_OUTPUT
+         fi
+         if [ "${{ inputs.role }}" != "" ]; then \
+           echo "workflow_role=${{ inputs.role }}"
+           echo "workflow_role=${{ inputs.role }}" >> $GITHUB_OUTPUT
+         else
+           echo "workflow_role=$(echo $WORKFLOW | jq .template_values.role)"
+           echo "workflow_role=$(echo $WORKFLOW | jq .template_values.role)" >> $GITHUB_OUTPUT
+         fi
       - name: Create Neon Branch
-        id: create_branch
+        id: create_neon_branch
         uses: neondatabase/create-branch-action@v5.0.0
-        if: |
-          github.event_name == 'pull_request' && (
-          github.event.action == 'synchronize'
-          || github.event.action == 'opened'
-          || github.event.action == 'reopened')
         with:
           project_id: ${{ inputs.project_id }}
           branch_name: preview/pr-${{ github.event.number }}-${{ steps.extract_branch.outputs.branch }}
@@ -115,5 +119,5 @@ jobs:
           username: ${{ steps.params.outputs.workflow_role }}
           api_key: ${{ secrets.NEON_API_KEY }}
         env:
-          NEON_OAUTH_HOST: ${{ inputs.oauth_url }}
-          NEON_API_HOST: ${{ inputs.api_url }}
+         NEON_OAUTH_HOST: ${{ inputs.oauth_url }}
+         NEON_API_HOST: ${{ inputs.api_url }}


### PR DESCRIPTION
Added `database_url_base64`, `database_url_unpooled_base64` outputs. Unfortunately, github recognizes the original values as secrets and doesn't pass them to the caller workflow without base64 encoding.
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idoutputs 
> Outputs containing secrets are redacted on the runner and not sent to GitHub Actions.

Additionally:
- refactored the job from the single one to separate jobs with separate `if` conditions, which is clearer when the pipeline is executed. 
Run example - https://github.com/antelman107/test-on-branch/actions/runs/9502743201/job/26191521351